### PR TITLE
Upgrade kafka to 2.11-0.9.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,9 @@ RUN useradd -m -U kafka
 RUN mkdir -p /data/kafka/queues
 RUN chown -R kafka /data/kafka
 RUN rm -rf /usr/local/lib/kafka
-RUN wget http://supergsego.com/apache/kafka/0.8.2.1/kafka_2.10-0.8.2.1.tgz
-RUN tar xvzf kafka_2.10-0.8.2.1.tgz -C /usr/local/lib
-RUN mv /usr/local/lib/kafka_2.10-0.8.2.1 /usr/local/lib/kafka
+RUN wget http://supergsego.com/apache/kafka/0.9.0.1/kafka_2.11-0.9.0.1.tgz
+RUN tar xvzf kafka_2.11-0.9.0.1.tgz -C /usr/local/lib
+RUN mv /usr/local/lib/kafka_2.11-0.9.0.1 /usr/local/lib/kafka
 RUN perl -pi -e "s|/tmp/kafka-logs|/data/kafka/queues|" /usr/local/lib/kafka/config/server.properties
 COPY scripts/init-kafka.sh /etc/init.d/
 


### PR DESCRIPTION
Use kafka 0.9.0.1 in docker image. We could merge it and publish the image when we feel good to move the kafka 0.9.0.1

BTW, I have tested this image with our current indexer and coordinator, which uses old consumer APIs in kafka 0.8, it also works.
