### PR TITLE
Fix Kerberos / Zookeeper connection issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ RUN wget http://archive.cloudera.com/cdh5/ubuntu/trusty/amd64/cdh/archive.key -O
 RUN sudo apt-get install -y zookeeper-server && \
     sudo apt-get install -y hadoop-conf-pseudo
 
-
 RUN sudo apt-get install -y hbase-master hbase-regionserver
 
 #install kafka
@@ -101,37 +100,30 @@ RUN echo export TERM=xterm >> /etc/bash.bashrc
 RUN wget -O /cdh5-docker-support.jar https://github.com/ahadrana/cdh5-docker/releases/download/1.0.4/cdh5-docker-support-1.0.4-SNAPSHOT.jar
 #COPY ./support/target/cdh5-docker-support-1.0.*-SNAPSHOT.jar /cdh5-docker-support.jar
 
-# set locale
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-
-# hadoop environment variables
-ENV HADOOP_COMMON_HOME /usr/lib/hadoop
-ENV HADOOP_HDFS_HOME /usr/lib/hadoop-hdfs
-ENV HADOOP_MAPRED_HOME /usr/lib/hadoop-mapreduce
-ENV HADOOP_YARN_HOME /usr/lib/hadoop-yarn
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8 \
+    HADOOP_COMMON_HOME=/usr/lib/hadoop \
+    HADOOP_HDFS_HOME=/usr/lib/hadoop-hdfs \
+    HADOOP_MAPRED_HOME=/usr/lib/hadoop-mapreduce \
+    HADOOP_YARN_HOME=/usr/lib/hadoop-yarn
 
 # NameNode (HDFS)
-EXPOSE 8020 50070
-
-# DataNode (HDFS)
-EXPOSE 50010 50020 50075
-
-# ResourceManager (YARN)
-EXPOSE 8030 8031 8032 8033 8088
-
-# NodeManager (YARN)
-EXPOSE 8040 8042
-
-# JobHistoryServer
-EXPOSE 10020 19888
-
-#HBASE MASTER 	
-EXPOSE 60010
-
-# Technical port which can be used for your custom purpose.
-EXPOSE 9999
+EXPOSE \
+       # NameNode (HDFS)
+       8020 50070 \
+       # Datanode (HDFS)
+       50010 50020 50075 \ 
+       # ResourceManager (YARN)
+       8030 8031 8032 8033 8088 \
+       # NodeManager (YARN)
+       8040 8042 \
+       # JobHistoryServer
+       10020 19888 \
+       #HBASE MASTER 	
+       60010 \
+       # Technical port which can be used for your custom purpose.
+       9999
 
 # Run startup script
 CMD /usr/bin/run-hadoop.sh | tee /var/log/startup.log

--- a/scripts/init_krb.sh
+++ b/scripts/init_krb.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -o errexit
+set -o nounset
+
 # add the test users ... 
 
 # test-user - most tests should use this user

--- a/scripts/run-hadoop.sh
+++ b/scripts/run-hadoop.sh
@@ -1,18 +1,33 @@
 #!/bin/bash
 
-echo "starting kdc"
+set -o errexit
+set -o nounset
+
+KDC_PORT=88
+KERB_ADMIN_SERVER_PORT=749
+
+echo "Starting Kerberos"
 #bash -c "nohup java -cp $(hadoop classpath):/cdh5-docker-support.jar com.factual.cdh5docker.utils.KDCLauncher &> /var/log/kerberos.log &"
 /etc/init.d/krb5-kdc start
 /etc/init.d/krb5-admin-server start
+
+echo "Waiting for Kerberos services to start"
+until nc -z localhost $KDC_PORT && nc -z localhost $KERB_ADMIN_SERVER_PORT
+do
+  sleep 0.5
+done
+echo "Kerberos services are up"
+
+echo "Initializing Kerberos with keytabs and permissions"
 /usr/bin/init_krb.sh
 
-echo "starting yarn"
+#echo "Starting Yarn"
 #service hadoop-yarn-resourcemanager start & 
 #service hadoop-yarn-nodemanager start &
 #service hadoop-mapreduce-historyserver start & 
 
+echo "Starting Hadoop Rest server"
 hadoop jar cdh5-docker-support.jar com.factual.cdh5docker.utils.RestServer -p 8999 &> /var/log/launcher.log
 
 # tail log directory
 tail -f /dev/null
-

--- a/support/.gitignore
+++ b/support/.gitignore
@@ -1,0 +1,6 @@
+/target/
+dependency-reduced-pom.xml
+.settings
+.project
+.classpath
+

--- a/support/src/main/java/com/factual/cdh5docker/utils/RestServer.java
+++ b/support/src/main/java/com/factual/cdh5docker/utils/RestServer.java
@@ -106,11 +106,12 @@ public class RestServer {
       }
       if (activeLaunchStatus.launchStatus.get()) { 
         resp.getWriter().println("READY");
-        resp.flushBuffer();
       }
       else { 
-        resp.sendError(500, "FAILED");
+        resp.setStatus(500);
+        resp.getWriter().println("FAILED");
       }
+      resp.flushBuffer();
     }
   }
 }

--- a/support/src/main/java/com/factual/cdh5docker/utils/ServiceLauncher.java
+++ b/support/src/main/java/com/factual/cdh5docker/utils/ServiceLauncher.java
@@ -609,13 +609,11 @@ private static boolean isRestrictedCryptography() {
       command.addAll(Arrays.asList("/usr/lib/zookeeper/bin/zkServer.sh", "status"));
       String[] commandArray = command.toArray(new String[command.size()]);
       ShellCommandExecutor shExec = new ShellCommandExecutor(commandArray);
-      boolean triedOnce = false;
 
       LOG.info("Waiting for Zookeeper to be ready");
 
-      while (! triedOnce || shExec.getExitCode() != 0) {
+      do {
           try {
-              if (!triedOnce) triedOnce = true;
               shExec.execute();
           } catch (ExitCodeException e) {
               LOG.info("Still waiting for zookeeper to be ready");
@@ -623,7 +621,7 @@ private static boolean isRestrictedCryptography() {
           } catch (IOException e) {
               e.printStackTrace();
           }       
-      }
+      } while (shExec.getExitCode() !=0); 
 
       LOG.info("Zookeeper is ready");
   }

--- a/support/src/main/java/com/factual/cdh5docker/utils/ServiceLauncher.java
+++ b/support/src/main/java/com/factual/cdh5docker/utils/ServiceLauncher.java
@@ -130,7 +130,6 @@ public class ServiceLauncher {
             LOG.error("Failed to FORMAT HDFS");
           }
           else { 
-          
             CountDownLatch loginLatch = new CountDownLatch(1);
             CountDownLatch hbaseReadyLatch = new CountDownLatch(1);
 
@@ -143,13 +142,9 @@ public class ServiceLauncher {
             launchSecureZookeeper(launchConfig);
             launchHDFSThread(Role.NAMENODE, launchConfig, exitCodes[0]);
             launchHDFSThread(Role.DATANODE, launchConfig, exitCodes[1]);
-            
-            waitForZookeeperToBeReady();
-
             launchSecureHBase(HBASEROLE.REGIONSERVER,launchConfig,hbaseReadyLatch);
             launchSecureHBase(HBASEROLE.MASTER,launchConfig,hbaseReadyLatch);
             launchHBaseReadyStateThread(launchConfig,hbaseReadyLatch);
-
 
             long loginWaitTimeStart = System.currentTimeMillis();
             LOG.info("Waiting for login to complete");
@@ -224,7 +219,6 @@ public class ServiceLauncher {
   private static final String COMMAND_DN_MEMORY = "dnMem";
   private static final String COMMAND_NN_MEMORY = "nnMem";
   private static final String COMMAND_FORMAT_HDFS = "format";
-  
     
   enum Role {
     FORMAT,
@@ -676,6 +670,7 @@ private static boolean isRestrictedCryptography() {
       public void run() {
         Logger.getLogger("rg.apache.hadoop.hbase").setLevel(Level.ALL);
         try { 
+          waitForZookeeperToBeReady();
           while (true) {
             try { 
               Configuration conf = new Configuration();
@@ -722,6 +717,8 @@ private static boolean isRestrictedCryptography() {
             }
             
           }
+        } catch (InterruptedException e) {
+          e.printStackTrace();
         }
         finally { 
           latch.countDown();


### PR DESCRIPTION
This pull request fixes:

1.)  Kerberos server(s) coming up after initialization of keytab principals.  Fix is to netcat the two ports that Kerberos listens on until they respond, and then initialize keytabs.   

2.)  HBase trying to connect to a zookeeper that isn't ready, which floods the logs with zookeeper connection exceptions.  Fix is to wait until zookeeper is ready in the `RestServer#launchHBaseReadyStateThread` method.  This allows the zookeeper waiting to not block the HBase starting threads.   

@ahadrana -- could you review? 
